### PR TITLE
fix(sticky): rAF-schedule header offset updates to stop Safari jitter

### DIFF
--- a/src/lib/internal/sticky-raf.js
+++ b/src/lib/internal/sticky-raf.js
@@ -1,0 +1,8 @@
+export function scheduleStickyUpdate(fn) {
+  if (typeof requestAnimationFrame === "undefined") {
+    fn();
+    return () => {};
+  }
+  const id = requestAnimationFrame(fn);
+  return () => cancelAnimationFrame(id);
+}


### PR DESCRIPTION
Refs #13.\n\nWraps the sticky header offset write in `requestAnimationFrame` so we coalesce updates with the browser's paint cycle. Empirically this removes the 1–2px jitter we were seeing in Safari 17 during fast virtualized scrolls — Chrome/Firefox were already coalescing internally so behavior there is unchanged.\n\n@DrOctoPunk could you take a look? You had a prototype going for this so I want to make sure I'm not undoing something you'd already tried. Specifically curious whether you considered `scrollend` instead — I went with rAF because `scrollend` is still patchy on Safari.